### PR TITLE
modifying theano_backend to not crash on cpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 **/*.h5
 **/*.ipynb_checkpoints
 **/*.bin
-**/*.tree
+**/*.tree_*
 **/*.weights
+**/*DS_Store

--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,12 +1,11 @@
 Metadata-Version: 1.1
 Name: modisco
-Version: 0.2
+Version: 0.2.1
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: NA
 Author: UNKNOWN
 Author-email: UNKNOWN
 License: UNKNOWN
 Download-URL: NA
-Description-Content-Type: UNKNOWN
 Description: UNKNOWN
 Platform: UNKNOWN

--- a/modisco/backend/theano_backend.py
+++ b/modisco/backend/theano_backend.py
@@ -1,7 +1,8 @@
 from __future__ import division, print_function
 import theano
 from theano import tensor as T
-#import theano.tensor.signal.pool #autoimported if on GPU
+from theano.tensor import signal
+from theano.tensor.signal import pool
 import numpy as np
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           url='NA',
           download_url='NA',
-          version='0.2',
+          version='0.2.1',
           packages=['modisco', 'modisco.cluster','modisco.backend',
                     'modisco.visualization', 'modisco.affinitymat',
                     'modisco.tfmodisco_workflow'],


### PR DESCRIPTION
theano.tensor.signal.pool is imported automatically with the GPU backend but not the CPU backend.