### PR TITLE
Bugfix for when len(split_patterns)==0

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: modisco
-Version: 0.3.5.1
+Version: 0.3.5.2
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: NA
 Author: UNKNOWN

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -652,6 +652,17 @@ class TfModiscoSeqletsToPatterns(AbstractSeqletsToPatterns):
         split_patterns = self.spurious_merge_detector(
                             cluster_to_motif.values())
 
+        if (len(split_patterns)==0):
+            if (self.verbose):
+                print("No more surviving patterns - bailing!")
+            return SeqletsToPatternsResults(
+                    patterns=None,
+                    seqlets=None,
+                    affmat=None,
+                    cluster_results=None, 
+                    total_time_taken=None,
+                    success=False)
+
         #Now start merging patterns 
         if (self.verbose):
             print("Merging on "+str(len(split_patterns))+" clusters")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           url='NA',
           download_url='NA',
-          version='0.3.5.1',
+          version='0.3.5.2',
           packages=['modisco', 'modisco.cluster','modisco.backend',
                     'modisco.visualization', 'modisco.affinitymat',
                     'modisco.tfmodisco_workflow', 'modisco.hit_scoring'],


### PR DESCRIPTION
Fix for https://github.com/kundajelab/tfmodisco/issues/21 - what appears to happen (based on the log provided), is that after aggregation the contribution scores of the resulting patterns have signs that disagree with the signs of the metacluster (likely suggesting the metacluster was not that well-supported to begin with). TF-MoDISco puts in a check for this and filters out any patterns that have a contribution score pattern that disagrees with the metacluster's sign. However, in the case that this filters out all the patterns, it results in a crash. I put in a check for this case that returns a dummy SeqletsToPatternsResults object with success=False. @Avsecz can you test it out?