### PR TITLE
Added sliding_similarities module with continuous jaccard

### DIFF
--- a/modisco/hit_scoring/fast_hit_scoring/entire_region_scoring.py
+++ b/modisco/hit_scoring/fast_hit_scoring/entire_region_scoring.py
@@ -1,71 +1,11 @@
-from __future__ import division, print_function, absolute_import
-from joblib import Parallel, delayed
+from modisco.sliding_similarities import parallel_sliding_continousjaccard
 
 
+# Old API
 def score_trackset_with_pattern(track_set, pattern,
                                 track_names, track_transformer, n_cores):
-    
+    pass
 
 
-def parallelcpu_score_full_regionarrs_with_perpos_continjaccard(
-    regionarrs_to_scan, arr_to_scan_with, n_cores):
-
-    assert len(arr_to_scan_with.shape)==2
-    for regionarr in regionarrs_to_scan:
-        assert len(regionarr.shape)==2
-        assert arr_to_scan_with.shape[-1] == regionarr.shape[-1]
-
-    
-    start = time.time()
-    #parallelize by input
-    job_arguments = []
-    for regionarr_to_scan in regionarrs_to_scan:
-        job_arguments.append((regionarr_to_scan, arr_to_scan_with))
-    
-    full_crosscontinjaccards =\
-        list(
-         Parallel(n_jobs=n_cores)(
-            delayed(score_full_regionarr_with_perpos_continjaccard)(*jobargs)
-            for jobargs in job_arguments))
-    return full_crosscontinjaccards
-
-
-def score_full_regionarr_with_perpos_continjaccard(regionarr_to_scan,
-                                                   arr_to_scan_with):
-    arr_to_scan_with_norm = np.sum(np.abs(arr_to_scan_with))
-
-    window_len = len(arr_to_scan_with)
-
-    #np.cumsum will give the cumulative sum at the *end* of every bin
-    per_pos_cum_sum_abs = np.cumsum(np.sum(np.abs(region_to_scan),axis=1))
-    #by subtracting per_pos_cumsum_abs[0], we can get the cumulative
-    # sum at the *start* of every bin. Then we can take the difference of the
-    # two at an offset of (window_len-1) to get the sums in windows of
-    # length window_len
-    per_pos_window_sum = (per_pos_cum_sum_abs[window_len-1:]
-                          - (per_pos_cum_sum_abs[:len(per_pos_cum_sum_abs)-
-                                                  (window_len-1)]-
-                             per_pos_cum_sum_abs[0]))
-    #per_pos_scale_factor is how much to scale the window sum by to equal
-    # the norm of arr_to_scan_with
-    per_pos_scale_factor = arr_to_scan_with_norm/(
-                            per_pos_window_sum+(0.0000001*
-                                                (per_pos_window_sum==0)))
-
-    full_crossmetric = np.zeros(len(regionarr_to_scan)+1-window_len)
-
-    absolute_arr_to_scan_with = np.abs(absolute_arr_to_scan_with)
-    signed_arr_to_scan_with = np.sign(absolute_arr_to_scan_with)
-
-    for idx in range(len(full_crossmetric)):
-        region_snapshot = (region_to_scan[idx:(idx+window_len)]
-                           *per_pos_scale_factor[idx]) 
-        abs_region_snapshot = np.abs(region_snapshot)
-        union = np.sum(np.maximum(abs_region_snapshot,
-                                  absolute_arr_to_scan_with))
-        intersection = np.sum(np.minimum(abs_region_snapshot,
-                                         absolute_arr_to_scan_with)*
-                              np.sign(region_snapshot)*
-                              signed_arr_to_scan_with)
-        full_crossmetric[:,idx] = intersection/union 
-    return full_crossmetric
+def parallelcpu_score_full_regionarrs_with_perpos_continjaccard(regionarrs_to_scan, arr_to_scan_with, n_cores):
+    return parallel_sliding_continousjaccard(arr_to_scan_with, regionarrs_to_scan, n_cores)

--- a/modisco/sliding_similarities.py
+++ b/modisco/sliding_similarities.py
@@ -1,0 +1,131 @@
+"""Implements various similarity metrics in a sliding-window fashion
+
+Main function: sliding_similarity
+
+General remarks:
+- qa: query array (pattern) of shape (query_seqlen, channels) used for scanning
+- ta: target array which gets scanned by qa of shape (..., target_seqlen, channels)
+
+by Ziga Avsec
+"""
+from __future__ import division, print_function, absolute_import
+from tqdm import tqdm
+from joblib import Parallel, delayed
+import numpy as np
+from scipy.signal import correlate
+
+
+def rolling_window(a, window_width):
+    """Create a new array suitable for rolling window operation
+
+    Adopted from http://www.rigtorp.se/2011/01/01/rolling-statistics-numpy.html,
+    also discussed in this PR: https://github.com/numpy/numpy/issues/7753
+
+    Args:
+      a: input array of shape (..., positions)
+      window_width: width of the window to scan
+
+    Returns:
+      array of shape (..., positions - window_width + 1, window_width)
+    """
+    shape = a.shape[:-1] + (a.shape[-1] - window_width + 1, window_width)
+    strides = a.strides + (a.strides[-1],)
+    return np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)
+
+
+def sliding_continousjaccard(qa, ta):
+    """Score the region with contionous jaccard
+    Args:
+      qa: query array (pattern) of shape (query_seqlen, channels) used for scanning
+      ta: target array which gets scanned by qa of shape (..., target_seqlen, channels)
+
+    Returns:
+      a tuple: (jaccard score of the normalized array, L1 magnitude of the scanned window)
+        both are of shape (..., target_seqlen - query_seqlen + 1)
+    """
+    qa = qa.swapaxes(-2, -1)  #
+    ta = ta.swapaxes(-2, -1)
+
+    assert ta.shape[-1] >= qa.shape[-1]  # target needs to be longer than the query
+
+    window_len = qa.shape[-1]
+    # out_len = qa.shape[-1] - window_len + 1
+
+    ta_strided = rolling_window(ta, window_len).swapaxes(-2, -1)
+
+    # compute the normalization factor
+    qa_L1_norm = np.sum(np.abs(qa))
+    ta_L1_norm = np.sum(np.abs(ta_strided), axis=(-3, -2))
+    per_pos_scale_factor = qa_L1_norm / (ta_L1_norm + (0.0000001 * (ta_L1_norm == 0)))
+
+    ta_strided_normalized = ta_strided * per_pos_scale_factor[..., np.newaxis, np.newaxis, :]
+
+    qa_strided = qa[..., np.newaxis]
+
+    ta_strided_normalized_abs = np.abs(ta_strided_normalized)
+    qa_strided_abs = np.abs(qa_strided)
+    union = np.sum(np.maximum(ta_strided_normalized_abs, qa_strided_abs), axis=(-3, -2))
+    # union = np.sum(np.maximum(np.abs(ta_strided_normalized), np.abs(qa_strided)), axis=(-3, -2))
+    intersection = np.sum(np.minimum(ta_strided_normalized_abs, qa_strided_abs) *
+                          np.sign(ta_strided_normalized) * np.sign(qa_strided), axis=(-3, -2))
+    return intersection / union, ta_L1_norm
+
+
+def parallel_sliding_continousjaccard(qa, ta, n_jobs=10, verbose=True):
+    """Parallel version of sliding_continousjaccard
+    """
+    r = np.stack(Parallel(n_jobs)(delayed(sliding_continousjaccard)(qa, ta[i])
+                                  for i in tqdm(range(len(ta)), disable=not verbose)))
+    return r[:, 0], r[:, 1]
+
+# ------------------------------------------------
+# PWM scanning
+
+
+def sliding_dotproduct(qa, ta):
+    """'convolution' implemented in numpy with valid padding
+    """
+    return correlate(ta, qa[np.newaxis], mode='valid')[..., 0]
+
+
+def parallel_sliding_dotproduct(qa, ta, n_jobs=10, verbose=True):
+    """Parallel version of sliding_dotproduct
+    """
+    return np.stack(Parallel(n_jobs)(delayed(sliding_dotproduct)(qa, ta[i][np.newaxis])
+                                     for i in tqdm(range(len(ta)), disable=not verbose)))[:, 0]
+
+
+def sliding_similarity(qa, ta, metric='continousjaccard', n_jobs=10, verbose=True):
+    """
+    Args:
+      qa (np.array): query array (pattern) of shape (query_seqlen, channels) used for scanning
+      ta (np.array): target array which gets scanned by qa of shape (..., target_seqlen, channels)
+      metric (str): similarity metric to use. Can be either from continousjaccard, dotproduct.
+        dotproduct implements 'convolution' in numpy
+
+    Returns:
+      single array for dotproduct or a tuple of two arrays for continousjaccard (match and magnitude)
+    """
+    if metric == 'continousjaccard':
+        return parallel_sliding_continousjaccard(qa, ta, n_jobs, verbose)
+    elif metric == 'dotproduct':
+        return parallel_sliding_dotproduct(qa, ta, n_jobs, verbose)
+    else:
+        raise ValueError("metric needs to be from: 'continousjaccard', 'dotproduct'")
+
+
+# --------------------------------------------
+# Example on how to implement pwm scanning using
+#
+# def pssm_scan(pwm, seqs, background_probs=[0.27, 0.23, 0.23, 0.27], n_jobs=10, verbose=True):
+#     """
+#     """
+#     def pwm2pssm(arr, background_probs):
+#         """Convert pwm array to pssm array
+#         pwm means that rows sum to one
+#         """
+#         arr = arr / arr.sum(1, keepdims=True)
+#         b = np.array(background_probs)[np.newaxis]
+#         return np.log(arr / b).astype(arr.dtype)
+#     pssm = pwm2pssm(pwm, background_probs)
+#     return sliding_metric(pssm, seqs, 'dotproduct', n_jobs, verbose)

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from distutils.core import setup
 
-if __name__== '__main__':
+if __name__ == '__main__':
     setup(include_package_data=True,
           description='TF MOtif Discovery from Importance SCOres',
           url='NA',
           download_url='NA',
           version='0.4.1.1',
-          packages=['modisco', 'modisco.cluster','modisco.backend',
+          packages=['modisco', 'modisco.cluster', 'modisco.backend',
                     'modisco.visualization', 'modisco.affinitymat',
+                    'modisco.cluster.phenograph',
                     'modisco.tfmodisco_workflow', 'modisco.hit_scoring'],
           setup_requires=[],
-          install_requires=['numpy>=1.9', 'joblib>=0.11', 
-                            'scikit-learn>=0.19',
+          install_requires=['numpy>=1.9', 'joblib>=0.11',
+                            'scikit-learn>=0.19', 'tqdm', 'scipy',
                             'h5py>=2.5'],
           extras_require={
-            'tensorflow': ['tensorflow>=1.7'],
-            'tensorflow with gpu': ['tensorflow-gpu>=1.7']},
+              'tensorflow': ['tensorflow>=1.7'],
+              'tensorflow with gpu': ['tensorflow-gpu>=1.7']},
           scripts=[],
           name='modisco')

--- a/test/test_sliding_similarity.py
+++ b/test/test_sliding_similarity.py
@@ -1,0 +1,45 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+import unittest
+from unittest import skip
+import sys
+import os
+import numpy as np
+from modisco import core
+import time
+from nose.tools import raises
+import pytest
+from modisco.sliding_similarities import sliding_continousjaccard, sliding_dotproduct, sliding_similarity
+
+
+class TestMetrics(unittest.TestCase):
+
+    def test_continousjaccard(self):
+        qa = np.random.randn(10, 4)
+        ta = np.random.randn(20, 100, 4)
+
+        match, size = sliding_continousjaccard(qa, ta)
+        assert match.shape == (20, 91)
+        assert size.shape == (20, 91)
+
+    def test_dotproduct(self):
+        qa = np.random.randn(10, 4)
+        ta = np.random.randn(20, 100, 4)
+
+        res = sliding_dotproduct(qa, ta)
+
+        assert res.shape == (20, 91)
+
+    def test_sliding_similarity(self):
+        qa = np.random.randn(10, 4)
+        ta = np.random.randn(20, 100, 4)
+
+        match, size = sliding_similarity(qa, ta, metric='continousjaccard', n_jobs=2)
+        match2, size2 = sliding_continousjaccard(qa, ta)
+        assert np.allclose(match, match2)
+        assert np.allclose(size, size2)
+
+        match = sliding_similarity(qa, ta, metric='dotproduct', n_jobs=2)
+        match2 = sliding_dotproduct(qa, ta)
+        assert np.allclose(match, match2)


### PR DESCRIPTION
I think we should have only one module for computing the similarity metrics which all of the downstream methods should use. I hence created a new module called `sliding_similarities`. This could also be renamed to `similarity_metrics` and it could then contain all the metrics including the normal non-sliding similarity metrics.