### PR TITLE
Few fixes and additional features

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: modisco
-Version: 0.5.8.1
+Version: 0.5.8.2
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: https://github.com/kundajelab/tfmodisco
 License: UNKNOWN

--- a/modisco/affinitymat/core.py
+++ b/modisco/affinitymat/core.py
@@ -478,6 +478,7 @@ class ParallelCpuCrossMetricOnNNpairs(AbstractSimMetricOnNNpairs):
         self.cross_metric_single_region = cross_metric_single_region
         self.verbose = verbose
 
+    #min_overlap is w.r.t. the length of 'filters'
     def __call__(self, filters, things_to_scan, min_overlap,
                        neighbors_of_things_to_scan=None,
                        return_sparse=False):

--- a/modisco/aggregator.py
+++ b/modisco/aggregator.py
@@ -276,7 +276,7 @@ class ReassignSeqletsFromSmallClusters(AbstractAggSeqletPostprocessor):
                 large_patterns, new_assignments =\
                     self.seqlet_assigner(patterns=large_patterns,
                                          seqlets_to_assign=seqlets_to_assign,
-                                         merge_into_existing_patterns=True)
+                                         merge_into_existing_patterns=False)
             large_patterns = self.postprocessor(large_patterns)
             return large_patterns
         else:

--- a/modisco/backend/tensorflow_backend.py
+++ b/modisco/backend/tensorflow_backend.py
@@ -1,5 +1,9 @@
 from __future__ import division, print_function
-import tensorflow as tf
+try:
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
+except:
+    import tensorflow as tf
 import numpy as np
 import sys
 

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -669,7 +669,6 @@ class TfModiscoSeqletsToPatterns(AbstractSeqletsToPatterns):
                                   " with "+str(motif.num_seqlets)
                                   +" seqlets due to sign disagreement")
                         cluster_to_eliminated_motif[i] = motif
-                cluster_to_motif[i] = motif
         return cluster_to_motif, cluster_to_eliminated_motif
 
 

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -507,11 +507,14 @@ class SeqletsToPatternsResults(object):
 
     def __init__(self,
                  each_round_initcluster_motifs, 
-                 patterns, cluster_results,
+                 patterns, 
+                 patterns_withoutreassignment,
+                 cluster_results,
                  total_time_taken, success=True, **kwargs):
         self.each_round_initcluster_motifs = each_round_initcluster_motifs
         self.success = success
         self.patterns = patterns
+        self.patterns_withoutreassignment = patterns_withoutreassignment
         self.cluster_results = cluster_results
         self.total_time_taken = total_time_taken
         self.__dict__.update(**kwargs)
@@ -553,11 +556,15 @@ class SeqletsToPatternsResults(object):
                         track_set=track_set)
             patterns = util.load_patterns(grp=grp["patterns"],
                                           track_set=track_set) 
+            patterns_withoutreassignment = util.load_patterns(
+                grp=grp["patterns_withoutreassignment"],
+                track_set=track_set) 
             cluster_results = None
             total_time_taken = None
             return cls(
                 each_round_initcluster_motifs=each_round_initcluster_motifs,
                 patterns=patterns,
+                patterns_withoutreassignment=patterns_withoutreassignment,
                 cluster_results=cluster_results,
                 total_time_taken=total_time_taken)
         else:
@@ -572,6 +579,9 @@ class SeqletsToPatternsResults(object):
                     grp=grp.create_group("each_round_initcluster_motifs"))
             util.save_patterns(self.patterns,
                                grp.create_group("patterns"))
+            util.save_patterns(
+                self.patterns_withoutreassignment,
+                grp.create_group("patterns_withoutreassignment"))
             self.cluster_results.save_hdf5(grp.create_group("cluster_results"))   
             grp.attrs['total_time_taken'] = self.total_time_taken
 
@@ -892,6 +902,8 @@ class TfModiscoSeqletsToPatterns(AbstractSeqletsToPatterns):
             sys.stdout.flush()
         reassigned_patterns = self.seqlet_reassigner(merged_patterns)
         final_patterns = self.final_postprocessor(reassigned_patterns)
+        final_patterns_withoutreassignment =\
+            self.final_postprocessor(merged_patterns)
         if (self.verbose):
             print("Got "+str(len(final_patterns))
                   +" patterns after reassignment")
@@ -908,6 +920,7 @@ class TfModiscoSeqletsToPatterns(AbstractSeqletsToPatterns):
         results = SeqletsToPatternsResults(
             each_round_initcluster_motifs=each_round_initcluster_motifs,             
             patterns=final_patterns,
+            patterns_withoutreassignment=final_patterns_withoutreassignment,
             seqlets=filtered_seqlets, #last stage of filtered seqlets
             #affmat=filtered_affmat,
             cluster_results=cluster_results, 

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -556,9 +556,12 @@ class SeqletsToPatternsResults(object):
                         track_set=track_set)
             patterns = util.load_patterns(grp=grp["patterns"],
                                           track_set=track_set) 
-            patterns_withoutreassignment = util.load_patterns(
-                grp=grp["patterns_withoutreassignment"],
-                track_set=track_set) 
+            if "patterns_withoutreassignment" in grp:
+                patterns_withoutreassignment = util.load_patterns(
+                    grp=grp["patterns_withoutreassignment"],
+                    track_set=track_set) 
+            else: #backwards compatibility
+                patterns_withoutreassignment = []
             cluster_results = None
             total_time_taken = None
             return cls(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.8.1',
+          version='0.5.8.2',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
Features/Fixes:
- When I did refactoring to include support for MEME initialization, I had a stray line that effectively caused the "sign consistency check" (which discards motifs for which the signs of the overall contribution scores disagrees with what you expect for the metacluster - such motifs can arise because seqlets get recentered during the various intermediate processing steps) to be bypassed (this effectively means a few extra motifs that seemed to have the wrong sign could have been returned). Related to the error encountered in https://github.com/kundajelab/tfmodisco/issues/66
- Made some minor fixes for tensorflow 2 support
- The final step of tf-modisco is a "reassignment" step where motifs that have a small number of seqlets are disbanded, and an attempt is made to "reassign" their seqlets to the other motifs. If they so desire, users can now access what the tfmodisco motifs are prior to this final reassignment step.