### PR TITLE
Potential fix for division-by-zero error

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: modisco
-Version: 0.5.9.1
+Version: 0.5.9.2
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: https://github.com/kundajelab/tfmodisco
 License: UNKNOWN

--- a/modisco/aggregator.py
+++ b/modisco/aggregator.py
@@ -880,7 +880,7 @@ class DynamicDistanceSimilarPatternsCollapser2(object):
                     #do a check about the per-example sum
                     per_ex_sum_pattern1_zeromask = (np.sum(np.abs(
                         flat_pattern1_fwdseqdata),axis=-1))==0
-                    per_ex_sum_pattern2 = (np.sum(np.abs(
+                    per_ex_sum_pattern2_zeromask = (np.sum(np.abs(
                         flat_pattern2_fwdseqdata),axis=-1))==0
                     if (np.sum(per_ex_sum_pattern1_zeromask) > 0):
                         print("WARNING: Zeros present for pattern1 coords")

--- a/modisco/aggregator.py
+++ b/modisco/aggregator.py
@@ -712,10 +712,12 @@ def compute_continjacc_vec_vs_arr(vec, arr):
     union = np.sum(np.maximum(abs_vec[None,:], abs_arr), axis=-1)
     intersection = np.sum((np.minimum(abs_vec[None,:], abs_arr)
                     *np.sign(vec[None,:])*np.sign(arr)), axis=-1)
+    zeros_mask = (union==0)
+    union = (union*(zeros_mask==False) + 1e-7*zeros_mask)
     return intersection/union
 
 
-def compute_continjacc_arr1_vs_arr2(arr1, arr2, n_cores):
+def compute_continjacc_arr1_vs_arr2(arr1, arr2, n_cores): 
     return np.array(
         Parallel(n_jobs=n_cores)(
             delayed(compute_continjacc_vec_vs_arr)(vec, arr2) for vec in arr1
@@ -873,6 +875,25 @@ class DynamicDistanceSimilarPatternsCollapser2(object):
                         flat_pattern1_revseqdata = None 
                         flat_pattern2_revseqdata = None 
                         assert rc==False
+
+                    #Do a check for all-zero scores, print warning
+                    #do a check about the per-example sum
+                    per_ex_sum_pattern1_zeromask = (np.sum(np.abs(
+                        flat_pattern1_fwdseqdata),axis=-1))==0
+                    per_ex_sum_pattern2 = (np.sum(np.abs(
+                        flat_pattern2_fwdseqdata),axis=-1))==0
+                    if (np.sum(per_ex_sum_pattern1_zeromask) > 0):
+                        print("WARNING: Zeros present for pattern1 coords")
+                        zero_seqlet_locs =\
+                            np.nonzero(per_ex_sum_pattern1_zeromask) 
+                        print("\n".join([str(s.coor) for s in
+                                         subsample_pattern1.seqlets]))
+                    if (np.sum(per_ex_sum_pattern2_zeromask) > 0):
+                        print("WARNING: Zeros present for pattern2 coords")
+                        zero_seqlet_locs =\
+                            np.nonzero(per_ex_sum_pattern2_zeromask)
+                        print("\n".join([str(coor) for coor in
+                                         pattern2_coords]))
 
                     between_pattern_sims =\
                      compute_continjacc_arr1_vs_arr2fwdandrev(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.9.1',
+          version='0.5.9.2',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
Alex confirmed that this fix works to prevent division-by-zero errors in the situation where certain stretches of the input importance score files have all-zero importance scores.