### PR TITLE
Changing sum-to-1 error to a warning for calculating information content

### DIFF
--- a/modisco/util.py
+++ b/modisco/util.py
@@ -474,9 +474,14 @@ def compute_per_position_ic(ppm, background, pseudocount):
     assert len(ppm.shape)==2
     assert ppm.shape[1]==len(background),\
             "Make sure the letter axis is the second axis"
-    assert (np.max(np.abs(np.sum(ppm, axis=1)-1.0)) < 1e-5),(
-             "Probabilities don't sum to 1 along axis 1 in "
-             +str(ppm)+"\n"+str(np.sum(ppm, axis=1)))
+    if (np.max(np.abs(np.sum(ppm, axis=1)-1.0)) < 1e-5):
+        print("WARNING: Probabilities don't sum to 1 in all the rows; this can"
+              +" be caused by zero-padding. Will renormalize. PPM:\n"
+              +str(ppm)
+              +"\nProbability sums:\n"
+              +str(np.sum(ppm, axis=1)))
+        ppm = ppm/np.sum(ppm, axis=1)[:,None]
+
     alphabet_len = len(background)
     ic = ((np.log((ppm+pseudocount)/(1 + pseudocount*alphabet_len))/np.log(2))
           *ppm - (np.log(background)*background/np.log(2))[None,:])

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.10.0',
+          version='0.5.10.1',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
Regarding Issue https://github.com/kundajelab/tfmodisco/issues/79

This error typically occurs when the user has sequences that are not perfectly one-hot encoded - i.e. some columns are all-zeros. This can result in a PPM where the probabilities don't sum to 1 in all the rows. The error is thrown when computing the information content for visualization purposes. The information content can still be calculated by simply renormalizing the rows to sum to 1, so that's what this workaround does (after printing a warning). The user should still make sure that they are ok with this behavior.