### PR TITLE
Added final subclustering step at the very end to reveal within-motif heterogeneity

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: modisco
-Version: 0.5.11.0
+Version: 0.5.12.0
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: https://github.com/kundajelab/tfmodisco
 License: UNKNOWN

--- a/modisco/hit_scoring/exemplar_based_hitscoring.py
+++ b/modisco/hit_scoring/exemplar_based_hitscoring.py
@@ -19,10 +19,6 @@ MotifHitAndCoord = namedtuple("MotifHitAndCoord",
                      "example_idx", "start", "end", "is_revcomp"]) 
 
 
-def flatten_seqlet_impscore_features(seqlet_impscores):
-    return np.reshape(seqlet_impscores, (len(seqlet_impscores), -1))
-
-
 def facility_locator(distmat, num_exemplars):
     exemplars = [] 
     current_bestrep = np.inf*np.ones(distmat.shape[0])
@@ -105,7 +101,8 @@ def get_exemplar_motifs(seqlets, pattern_comparison_settings,
          pattern_comparison_settings.track_transformer)
     #flatten the fwd_seqlet_data (they are aligned so it's ok to flatten
     # them before doing comparisons)
-    fwd_seqlet_data_vectors = flatten_seqlet_impscore_features(fwd_seqlet_data)
+    fwd_seqlet_data_vectors = util.flatten_seqlet_impscore_features(
+                                        fwd_seqlet_data)
     #compute the affinity matrix
     orig_affmat = compute_pairwise_continjacc_sims(
         vecs1=fwd_seqlet_data_vectors,
@@ -124,13 +121,13 @@ def get_exemplar_motifs(seqlets, pattern_comparison_settings,
                if is_passing]
     filtered_orig_motif = make_aggregated_seqlet(seqlets)
     
-    
     #convert to distance matrix
     distmat = 1/( np.maximum(affmat,1e-7) )
     #get exemplars
     seqlet_exemplar_indices = facility_locator(
         distmat=distmat,
-        num_exemplars=min(max_exemplars, int(np.ceil(len(seqlets)/seqlets_per_exemplar)) ))
+        num_exemplars=min(max_exemplars,
+                          int(np.ceil(len(seqlets)/seqlets_per_exemplar)) ))
     #aggregate over the similar ones, return the aggseqlets
     representive_exemplars = np.argmax(affmat[:, seqlet_exemplar_indices],
                                          axis=-1)
@@ -263,7 +260,7 @@ class FeaturesProducer(object):
                 track_transformer=pattern_comparison_settings.track_transformer)
         #Flatten the importance score data into vectors
         self.allexemplarmotifs_impscoresdata_fwd = (
-            flatten_seqlet_impscore_features(
+            util.flatten_seqlet_impscore_features(
                 allexemplarmotifs_impscoresdata_fwd))
 
         #Do the same for per-position IC (for weighting exemplar sim
@@ -276,7 +273,7 @@ class FeaturesProducer(object):
         #compute the per-position IC, then tile (for ACGT) and flatten to
         # get it into vector form.
         self.per_position_ic_allexemplarmotifs_fwd =\
-            np.maximum(flatten_seqlet_impscore_features(np.array([
+            np.maximum(util.flatten_seqlet_impscore_features(np.array([
                 np.tile(util.compute_per_position_ic(
                     ppm=x,
                     background=bg_freq,
@@ -294,7 +291,7 @@ class FeaturesProducer(object):
                track_transformer=
                 self.pattern_comparison_settings.track_transformer)
         #Flatten the importance score data into vectors
-        impscoresdata_fwd = (flatten_seqlet_impscore_features(
+        impscoresdata_fwd = (util.flatten_seqlet_impscore_features(
                              impscoresdata_fwd))
 
         start = time.time()

--- a/modisco/util.py
+++ b/modisco/util.py
@@ -5,6 +5,7 @@ import subprocess
 import numpy as np
 import h5py
 import traceback
+import scipy.sparse
 
 
 def print_memory_use():
@@ -35,6 +36,20 @@ def save_patterns(patterns, grp):
         pattern.save_hdf5(pattern_grp)
     save_string_list(all_pattern_names, dset_name="all_pattern_names",
                      grp=grp)
+
+
+def flatten_seqlet_impscore_features(seqlet_impscores):
+    return np.reshape(seqlet_impscores, (len(seqlet_impscores), -1))
+
+
+def coo_matrix_from_neighborsformat(entries, neighbors, ncols):
+    coo_mat = scipy.sparse.coo_matrix(
+            (np.concatenate(entries, axis=0),
+             (np.array([i for i in range(len(neighbors))
+                           for j in neighbors[i]]).astype("int"),
+              np.concatenate(neighbors, axis=0)) ),
+            shape=(len(entries), ncols)) 
+    return coo_mat
 
 
 def load_string_list(dset_name, grp):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.11.0',
+          version='0.5.12.0',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
- Performs density-adapted clustering (Leiden) + computes a tsne embedding. By default, perplexity of 30 is used for both. If TF-MoDISco is run with this version from the beginning, the subclustering will automatically be computed for each motif. Otherwise, motifs computed with a previous version can be loaded and the subclutering computed post-hoc.
- Uses all-pairwise continuous jaccard similarities for computing the similarity matrix, but is memory efficient because the number of nearest neighbors used to perform the density adaptation is far smaller (it's perplexity*3 + 1) than the total number of nodes in the graph (only the similarities for the necessary number of nearest neighbors are kept in memory)
- Added support for saving and loading the subclustering from file

Notebook demonstrating the change on the example tal-gata notebook: https://github.com/kundajelab/tfmodisco/blob/c2c6001b8a2608ee5224ac7faeb69d5fd72f78f5/examples/simulated_TAL_GATA_deeplearning/TF_MoDISco_TAL_GATA.ipynb

Notebook demonstrating how to compute the subclustering post-hoc:
http://mitra.stanford.edu/kundaje/avanti/tfmodisco_bio_experiments/bpnet/trial1/TryBpNet_v0.5.12.0_add_in_subclustering.html
(github permalink: https://github.com/kundajelab/tfmodisco_bio_experiments/blob/54df6faa20773d91107e7b645649e2145e3fb0de/bpnet/trial1/TryBpNet_v0.5.12.0_add_in_subclustering.ipynb)