### PR TITLE
Parallelizing Leiden

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: modisco
-Version: 0.5.12.0
+Version: 0.5.13.0
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: https://github.com/kundajelab/tfmodisco
 License: UNKNOWN

--- a/modisco/cluster/run_leiden
+++ b/modisco/cluster/run_leiden
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+from __future__ import division, print_function
+import argparse
+import numpy as np
+import igraph as ig
+import leidenalg
+
+
+#based on https://github.com/theislab/scanpy/blob/8131b05b7a8729eae3d3a5e146292f377dd736f7/scanpy/_utils.py#L159
+def get_igraph(sources_idxs_file, targets_idxs_file, weights_file, n_vertices):
+    sources = np.load(sources_idxs_file) 
+    targets = np.load(targets_idxs_file) 
+    weights = np.load(weights_file)
+    g = ig.Graph(directed=None) 
+    g.add_vertices(n_vertices) # this adds adjacency.shap[0] vertices
+    g.add_edges(list(zip(sources, targets))) 
+    g.es['weight'] = weights                                                
+    if g.vcount() != adjacency.shape[0]: 
+        print('WARNING: The constructed graph has only ' 
+              +str(g.vcount())+' nodes. ' 
+             'Your adjacency matrix contained redundant nodes.') 
+    return g 
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser() 
+    parser.add_argument("--sources_idxs_file", required=True)    
+    parser.add_argument("--targets_idxs_file", required=True)    
+    parser.add_argument("--weights_file", required=True)    
+    parser.add_argument("--n_vertices", type=int, required=True) 
+    parser.add_argument("--partition_type", required=True) 
+    parser.add_argument("--n_leiden_iterations", type=int, required=True) 
+    parser.add_argument("--initial_membership_file", default=None,
+                        required=False) 
+    parser.add_argument("--seed", type=int, required=True) 
+
+    args = parser.parse_args()
+
+    the_graph = get_igraph(
+        sources_idxs_file=args.sources_idxs_file,
+        targets_idxs_file=args.targets_idxs_file,
+        weights_file=args.weights_file,
+        n_vertices=args.n_vertices)
+
+    partition_type = eval("leidenalg."+args.partition_type) 
+    n_iterations = args.n_iterations
+    initial_membership = (None if args.initial_membership_file is None
+                          else np.load(args.initial_membership_file))
+    seed = args.seed
+
+    partition = leidenalg.find_partition(
+        the_graph=the_graph,
+        partition_type=partition_type,
+        weights=(np.array(the_graph.es['weight']).astype(np.float64)),                              
+        n_iterations=n_iterations,                      
+        initial_membership=initial_membership,                     
+        seed=seed) 
+
+    quality = partition.quality()
+    print("########################")
+    print("Quality:",quality)
+    print("Membership:")
+    print(",".join[str(x) for x in partition.membership]) 

--- a/modisco/cluster/run_leiden
+++ b/modisco/cluster/run_leiden
@@ -4,6 +4,7 @@ import argparse
 import numpy as np
 import igraph as ig
 import leidenalg
+import sys
 
 
 #based on https://github.com/theislab/scanpy/blob/8131b05b7a8729eae3d3a5e146292f377dd736f7/scanpy/_utils.py#L159
@@ -14,8 +15,8 @@ def get_igraph(sources_idxs_file, targets_idxs_file, weights_file, n_vertices):
     g = ig.Graph(directed=None) 
     g.add_vertices(n_vertices) # this adds adjacency.shap[0] vertices
     g.add_edges(list(zip(sources, targets))) 
-    g.es['weight'] = weights                                                
-    if g.vcount() != adjacency.shape[0]: 
+    g.es['weight'] = weights       
+    if g.vcount() != n_vertices: 
         print('WARNING: The constructed graph has only ' 
               +str(g.vcount())+' nodes. ' 
              'Your adjacency matrix contained redundant nodes.') 
@@ -29,7 +30,7 @@ if __name__ == "__main__":
     parser.add_argument("--weights_file", required=True)    
     parser.add_argument("--n_vertices", type=int, required=True) 
     parser.add_argument("--partition_type", required=True) 
-    parser.add_argument("--n_leiden_iterations", type=int, required=True) 
+    parser.add_argument("--n_iterations", type=int, required=True) 
     parser.add_argument("--initial_membership_file", default=None,
                         required=False) 
     parser.add_argument("--seed", type=int, required=True) 
@@ -49,7 +50,7 @@ if __name__ == "__main__":
     seed = args.seed
 
     partition = leidenalg.find_partition(
-        the_graph=the_graph,
+        graph=the_graph,
         partition_type=partition_type,
         weights=(np.array(the_graph.es['weight']).astype(np.float64)),                              
         n_iterations=n_iterations,                      
@@ -60,4 +61,5 @@ if __name__ == "__main__":
     print("########################")
     print("Quality:",quality)
     print("Membership:")
-    print(",".join[str(x) for x in partition.membership]) 
+    print("\n".join(str(x) for x in partition.membership))
+    sys.stdout.flush() 

--- a/modisco/core.py
+++ b/modisco/core.py
@@ -774,7 +774,8 @@ class AggregatedSeqlet(Pattern):
 
         twod_embedding = sklearn.manifold.TSNE(
             perplexity=perplexity,
-            metric='precomputed', verbose=3).fit_transform(distmat_sp) 
+            metric='precomputed',
+            verbose=3, random_state=1234).fit_transform(distmat_sp) 
         self.twod_embedding = twod_embedding
 
         #do density adaptation
@@ -786,11 +787,12 @@ class AggregatedSeqlet(Pattern):
                                         affmat_nn, seqlet_neighbors)
 
         #Do Leiden clustering
-        clusterer = cluster.core.LeidenCluster(
+        clusterer = cluster.core.LeidenClusterParallel(
+                n_jobs=n_jobs,
                 affmat_transformer=
                     affinitymat.transformers.SymmetrizeByAddition(
                                                    probability_normalize=True),
-                contin_runs=50,
+                numseedstotry=50,
                 n_leiden_iterations=-1,
                 verbose=verbose)
         cluster_results = clusterer(sp_density_adapted_affmat,

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -278,15 +278,6 @@ class TfModiscoSeqletsToPatternsFactory(object):
                 zip(hypothetical_contribs_track_names,
                     [np.sign(x) for x in track_signs])))
 
-        ##affinity matrix from embeddings
-        #coarse_affmat_computer =\
-        #    affinitymat.core.AffmatFromSeqletEmbeddings(
-        #        seqlets_to_1d_embedder=seqlets_to_1d_embedder,
-        #        affinity_mat_from_1d=\
-        #            affinitymat.core.NumpyCosineSimilarity(
-        #                verbose=self.verbose),
-        #        verbose=self.verbose)
-
         #affinity matrix from embeddings
         coarse_affmat_computer =\
             affinitymat.core.SparseAffmatFromFwdAndRevSeqletEmbeddings(
@@ -335,9 +326,10 @@ class TfModiscoSeqletsToPatternsFactory(object):
                 contin_runs=self.contin_runs_r1,
                 verbose=self.verbose, seed=self.seed)
         else:
-            clusterer_r1 = cluster.core.LeidenCluster(
+            clusterer_r1 = cluster.core.LeidenClusterParallel(
+                n_jobs=self.n_cores, 
                 affmat_transformer=affmat_transformer_r1,
-                contin_runs=self.contin_runs_r1,
+                numseedstotry=self.contin_runs_r1,
                 n_leiden_iterations=self.n_leiden_iterations_r1,
                 verbose=self.verbose)
 
@@ -357,9 +349,10 @@ class TfModiscoSeqletsToPatternsFactory(object):
                 verbose=self.verbose, seed=self.seed,
                 initclusters_weight=self.louvain_initclusters_weight)
         else:
-            clusterer_r2 = cluster.core.LeidenCluster(
+            clusterer_r2 = cluster.core.LeidenClusterParallel(
+                n_jobs=self.n_cores, 
                 affmat_transformer=affmat_transformer_r2,
-                contin_runs=self.contin_runs_r2,
+                numseedstotry=self.contin_runs_r2,
                 n_leiden_iterations=self.n_leiden_iterations_r2,
                 verbose=self.verbose)
         

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.12.0',
+          version='0.5.13.0',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
`leidenalg.find_partition` cannot be parallelized naively via joblib because it results in a `TypeError: cannot pickle ‘PyCapsule’ object` error. So instead, parallelism is achieved by making calls to a dedicated script that runs leiden community detection that is called using `subprocess.Popen`. Results on bpnet nanog task (gives the same results as before, but spends noticeably less time on the Leiden clustering steps): http://nbviewer.jupyter.org/github/kundajelab/tfmodisco_bio_experiments/blob/b3b4d7b240b8e398597100581ae791eec0a13b61/bpnet/trial1/TryBpNet_v0.5.13.0.ipynb