### PR TITLE
Fixed setup.py to include run_leiden, fixed num threads for agkm embedding

### DIFF
--- a/modisco.egg-info/PKG-INFO
+++ b/modisco.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: modisco
-Version: 0.5.13.0
+Version: 0.5.13.1
 Summary: TF MOtif Discovery from Importance SCOres
 Home-page: https://github.com/kundajelab/tfmodisco
 License: UNKNOWN

--- a/modisco.egg-info/SOURCES.txt
+++ b/modisco.egg-info/SOURCES.txt
@@ -25,6 +25,7 @@ modisco/backend/tensorflow_backend.py
 modisco/backend/theano_backend.py
 modisco/cluster/__init__.py
 modisco/cluster/core.py
+modisco/cluster/run_leiden
 modisco/cluster/phenograph/__init__.py
 modisco/cluster/phenograph/bruteforce_nn.py
 modisco/cluster/phenograph/cluster.py

--- a/modisco/seqlet_embedding/advanced_gapped_kmer.py
+++ b/modisco/seqlet_embedding/advanced_gapped_kmer.py
@@ -170,7 +170,7 @@ class AdvancedGappedKmerEmbedderFactory(object):
 
     def __init__(self, topn=20, min_k=4, max_k=6, max_gap=15, max_len=15, 
                        max_entries=500,
-                       alphabet_size=4, n_jobs=10):
+                       alphabet_size=4):
         self.topn = topn
         self.min_k = min_k
         self.max_k = max_k
@@ -178,7 +178,6 @@ class AdvancedGappedKmerEmbedderFactory(object):
         self.max_len = max_len
         self.max_entries = max_entries
         self.alphabet_size = alphabet_size
-        self.n_jobs = n_jobs
 
     def get_jsonable_config(self):
         return OrderedDict([
@@ -189,16 +188,17 @@ class AdvancedGappedKmerEmbedderFactory(object):
                 ('max_len', self.max_len),
                 ('max_entries', self.max_entries),
                 ('alphabet_size', self.alphabet_size),
-                ('n_jobs', self.n_jobs)
                 ])
 
-    def __call__(self, onehot_track_name, toscore_track_names_and_signs):
+    def __call__(self, onehot_track_name,
+                       toscore_track_names_and_signs,
+                       n_jobs):
         return AdvancedGappedKmerEmbedder(
                 topn=self.topn, min_k=self.min_k, max_k=self.max_k,
                 max_gap=self.max_gap, max_len=self.max_len,
                 max_entries=self.max_entries,
                 alphabet_size=self.alphabet_size,
-                n_jobs=self.n_jobs,
+                n_jobs=n_jobs,
                 onehot_track_name=onehot_track_name,
                 toscore_track_names_and_signs=toscore_track_names_and_signs) 
 

--- a/modisco/tfmodisco_workflow/seqlets_to_patterns.py
+++ b/modisco/tfmodisco_workflow/seqlets_to_patterns.py
@@ -276,7 +276,8 @@ class TfModiscoSeqletsToPatternsFactory(object):
                 onehot_track_name=onehot_track_name,
                 toscore_track_names_and_signs=list(
                 zip(hypothetical_contribs_track_names,
-                    [np.sign(x) for x in track_signs])))
+                    [np.sign(x) for x in track_signs])),
+                n_jobs=self.n_cores)
 
         #affinity matrix from embeddings
         coarse_affmat_computer =\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.13.0',
+          version='0.5.13.1',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']
@@ -21,5 +21,5 @@ if __name__== '__main__':
           extras_require={
             'tensorflow': ['tensorflow>=1.7'],
             'tensorflow with gpu': ['tensorflow-gpu>=1.7']},
-          scripts=[],
+          scripts=['modisco/cluster/run_leiden'],
           name='modisco')


### PR DESCRIPTION
- Package installation was broken because run_leiden wasn't listed under scripts
- Number of threads used for Agkm embedding had to be specified separately from the number of threads used elsewhere, leading to the default number of threads being different than the user-specified number. This has been fixed.