### PR TITLE
fix tsne sparse input matrix error

### DIFF
--- a/modisco/core.py
+++ b/modisco/core.py
@@ -772,11 +772,11 @@ class AggregatedSeqlet(Pattern):
         #convert to csr and sort by indices to (try to) get rid of efficiency warning
         distmat_sp = distmat_sp.tocsr()
         distmat_sp.sort_indices()
-
         if (compute_embedding):
             twod_embedding = sklearn.manifold.TSNE(
                 perplexity=perplexity,
                 metric='precomputed',
+                init="random",
                 verbose=3, random_state=1234).fit_transform(distmat_sp) 
             self.twod_embedding = twod_embedding
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__== '__main__':
           description='TF MOtif Discovery from Importance SCOres',
           long_description="""Algorithm for discovering consolidated patterns from base-pair-level importance scores""",
           url='https://github.com/kundajelab/tfmodisco',
-          version='0.5.16.2',
+          version='0.5.16.3',
           packages=find_packages(),
           package_data={
                 '': ['cluster/phenograph/louvain/*convert*', 'cluster/phenograph/louvain/*community*', 'cluster/phenograph/louvain/*hierarchy*']


### PR DESCRIPTION
This PR fixes the following error: 

>   File "modisco/core.py", line 777, in compute_subclusters_and_embedding     
>     twod_embedding = sklearn.manifold.TSNE(         
> TypeError: PCA initialization is currently not supported with the sparse input matrix. Use init="random" instead.  

